### PR TITLE
Allow for multiple `og-grid` elements on the same page

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -124,7 +124,7 @@
 
 			var Grid = (function() {
 
-				var $grid = $( '#og-grid' ),
+				var $grid = $( '*#og-grid' ),
 					$items = $grid.children( 'li' ),
 					current = -1,
 					previewPos = -1,
@@ -260,7 +260,7 @@
 
 				function Preview( $item ) {
 					this.$item = $item;
-					this.expandedIdx = this.$item.index();
+					this.expandedIdx = Array.from($items).findIndex(d => d == this.$item[0]);
 					this.create();
 					this.update();
 				}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -213,7 +213,7 @@
 					} ).children( 'a' ).on( 'click', function(e) {
 
 						var $item = $( this ).parent();
-						current === $item.index() ? hidePreview() : showPreview( $item );
+						current === Array.from($items).findIndex(d => d == $item[0]) ? hidePreview() : showPreview( $item );
 						return false;
 
 					} );


### PR DESCRIPTION
With the current javascript code, if multiple grids (`og-grid` elements) are initialized on the page, only the items of the first one will have a working interaction when they are clicked on.

This PR allows the `on('click)'` interaction to work for all the elements of all the grids if multiple grids sections are initialized on the same page.

e.g.:  if the data in `items` are a list of categories and the `index.html` in `layouts` is modified like so:

```
<div class="main">
  {{ range $.Site.Data.items.categories}}
    <div>
      <div class="title">{{.title}}</div>
      <p class="description">{{.description | markdownify}}</p>
      <ul id="og-grid" class="og-grid">
        {{ range .items }}
          <li>
            <a href="{{.url}}" data-largesrc="{{.image}}" data-title="{{.title}}" data-description="{{.description}}" data-buttontext="{{.buttontext}}">
              <img src="{{.thumb}}" alt="{{.alt}}"/>
            </a>
          </li>
        {{ end }}
      </ul>
    </div>
  {{ end }}
  {{ partial "footer.html" . }}
</div>
```

![Imgur](https://i.imgur.com/gcrY1Pq.png)